### PR TITLE
fix(enums/country code): add YU

### DIFF
--- a/src/Enums/CountryCodeEnum.php
+++ b/src/Enums/CountryCodeEnum.php
@@ -742,6 +742,9 @@ enum CountryCodeEnum: string
     /** Mayotte */
     case YT = 'YT';
 
+    /** Yugoslavia */
+    case YU = 'YU';
+
     /** South Africa */
     case ZA = 'ZA';
 


### PR DESCRIPTION
For some reason some items still have YU country code, for example:
https://www.ebay.com/itm/267162035820?_skw=Fat+Chance&hash=item3e3419266c:g:ylQAAOSwuMNmnkHX

This cause exception: `Symfony\Component\Serializer\Exception\NotNormalizableValueException: The data must belong to a backed enumeration of type SapientPro\EbayBrowseSDK\Enums\CountryCodeEnum`