### PR TITLE
getClientToken now accepts scope

### DIFF
--- a/src/Api/OAuthApi.php
+++ b/src/Api/OAuthApi.php
@@ -71,6 +71,7 @@ class OAuthApi implements EbayApiInterface
      * <p>This method retrieves a valid OAuth token.</p><p>All eBay REST APIs use the OAuth 2.0 protocol for application and user authorization. OAuth is the industry standard for assuring your online transactions are secure and you must provide a valid access token for each request you make to the eBay REST interfaces. <a href="/api-docs/static/oauth-client-credentials-grant.html">API Restrictions</a></p><h3><b> Request headers</b></h3> Set the following HTTP request headers:<ul><li>Content-Type – Must be set to: application/x-www-form-urlencoded</li><li>Authorization – The word "Basic " followed by your Base64-encoded OAuth credentials (<code><client_id>:<client_secret></code>).</li></ul> For details, see <a href="/api-docs/static/oauth-base64-credentials.html">Generating your Base64-encoded credentials</a>.<h3><b> Restrictions </b></h3>Format the payload of your POST request with the following values:<ul><li>Set grant_type to client_credentials.</li><li>Set scope to the URL-encoded space-separated list of the scopes needed for the interfaces you call with the access token.</li></ul>For details, see <a href="/api-docs/static/oauth-scopes.html#specifying-scopes">Using OAuth to access eBay APIs</a>.
      * @param array $clientId Array ['SANDBOX' => '', 'PRODUCTION' => ''] of application keys App ID (Client ID).
      * @param array $clientSecret Array ['SANDBOX' => '', 'PRODUCTION' => ''] of application keys Cert ID (Client Secret).
+     * @param array|null $scope Array of SapientPro\EbayBrowseSDK\Enums\OAuthTokenScopesEnum of the scopes needed for the interfaces you call with the access token.
      * @return OAuthToken|null
      * @throws ApiException on non-2xx response
      */
@@ -81,7 +82,8 @@ class OAuthApi implements EbayApiInterface
         $response = $this->getOAuthWithHttpInfo(
             $clientId,
             $clientSecret,
-            GrantTypeEnum::CLIENT_CREDENTIALS
+            GrantTypeEnum::CLIENT_CREDENTIALS,
+            ?array $scope = null
         );
         return $response['data'] ?? null;
     }


### PR DESCRIPTION
Unless I'm missing something, `getClientToken` needs `scopes` to be useful.  Otherwise, the API returns the error: `Insufficient permissions to fulfill the request` when performing a request with the returned access token.  This may be true for `getAuthorizationToken` as well.